### PR TITLE
style: remove blue highlight backgroud when tap on mobile screen

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -19,3 +19,7 @@ body {
   height: 100%;
   background: theme('colors.beige');
 }
+
+* {
+  -webkit-tap-highlight-color: transparent;
+}


### PR DESCRIPTION
source : https://stackoverflow.com/questions/45049873/how-to-remove-the-blue-highlight-of-button-on-mobile